### PR TITLE
Fix broken dynamic library compile on osx

### DIFF
--- a/dyn_langs_to_go/go_adder/Makefile
+++ b/dyn_langs_to_go/go_adder/Makefile
@@ -2,13 +2,15 @@ UNAME := $(shell uname)
 
 ifeq ($(UNAME), Darwin) 
     DYLIB_EXT := .dylib
+    FLAGS := -ldflags -s
 else
     DYLIB_EXT := .so
+    FLAGS := ''
 endif
 
 libadder$(DYLIB_EXT):
 	# New in Go 1.5, build Go dynamic lib
-	go build -o $@ -buildmode=c-shared
+	go build $(FLAGS) -o $@ -buildmode=c-shared
 
 clean:
 	rm -f libadder.*


### PR DESCRIPTION
It was remarkably hard tracking down the problem.
I found the solution here:
https://github.com/openai/universe/issues/167

Without this fix, I was getting an error that looked like this:
```
> python python_to_go.py
Traceback (most recent call last):
  File "python_to_go.py", line 12, in <module>
    lib = cdll.LoadLibrary('go_adder/libadder.' + lib_extension())
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ctypes/__init__.py", line 440, in LoadLibrary
    return self._dlltype(name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ctypes/__init__.py", line 362, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(go_adder/libadder.dylib, 6): no suitable image found.  Did find:
	go_adder/libadder.dylib: malformed mach-o image: segment __DWARF vm overlaps segment __LINKEDIT
	/Users/steventroxler/kode/scratch/go-interlang/dyn_langs_to_go/go_adder/libadder.dylib: malformed mach-o image: segment __DWARF vm overlaps segment __LINKEDIT
```